### PR TITLE
[codex] add aimax domain redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,18 @@
 {
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
+          "value": "aimax.ai.kr"
+        }
+      ],
+      "destination": "https://makefamily.kr/index.html",
+      "permanent": false
+    }
+  ],
   "functions": {
     "src/app/api/sns/scrape/route.ts": {
       "maxDuration": 60


### PR DESCRIPTION
## What changed

- Added a Vercel redirect rule for requests whose `Host` header is `aimax.ai.kr`.
- Redirects all paths on that domain to `https://makefamily.kr/index.html`.
- Uses a temporary redirect (`permanent: false`) so the target can be changed later without browser-cached permanent redirects getting in the way.

## Why

The existing QR code points to `aimax.ai.kr`, but the desired destination is now the Makefamily page. This keeps the QR code usable without changing the printed/generated QR asset.

## Validation

- Parsed `vercel.json` locally with Node to verify valid JSON.
- Confirmed the diff is limited to `vercel.json`.

Production takes effect after this PR is merged and Vercel deploys `main`.